### PR TITLE
fix: manage unpopulated relationships with exotic ids (not string or number)

### DIFF
--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -22,7 +22,7 @@ module.exports = function serializeResource(payload, data, options, cb) {
         // process data
         data: function processData(fn) {
             let isAnId = function(i) {
-                    return _.isString(i) || _.isNumber(i);
+                    return !_.isPlainObject(i);
                 },
                 convertToShell = function(i) {
                     i = {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "lodash": "^4.5.0"
   },
   "devDependencies": {
+    "bson-objectid": "^1.1.4",
     "chai": "^3.5.0",
     "grunt": "^0.4.5",
     "grunt-mocha-istanbul": "^3.0.1",


### PR DESCRIPTION
When working with mongo or mongoose data, unpopulated relationships are mongo ObjectId or Array of mongo ObjectId. So the method `isAndId` doesn't detect it, and the serializer throw an exception `Missing required`id`attribute`.

I know that we have the method `processResource`, or we can pre-process data before serialize, if we want to convert all mongo ObjectId to string, but it decrease performance, especially on huge array.

So let's consider that if we have not a plain object in relationships, it's an unpopulated relationships with id or array of ids (with maybe exotic one like mongo ObjectId)
