### PR TITLE
fixed a bug that was causing my whole object to be set as the id prop…

### DIFF
--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -36,7 +36,12 @@ module.exports = function serializeResource(payload, data, options, cb) {
         // process data
         data: ['processResource', function processData(fn) {
             let isAnId = function(i) {
-                    return !_.isPlainObject(i);
+                    
+                    //if you have a TYPED object (e.g. of type user -> instanceof === User)
+                    //this will return false and break this whole thing
+                    //return !_.isPlainObject(i);
+
+                    return !_.isObject(i);                    
                 },
                 convertToShell = function(i) {
                     i = {


### PR DESCRIPTION
…erty using the instructions from the read me with my resource

it's because the prototype is not null like an object literal.. if you read carefully on the lodash docs you'll see why https://lodash.com/docs#isPlainObject

the function convertToShell was running and returning a new object with a key of the object's id's key and a value of the resource object.

this fixes the issues. otherwise all cool! :)
