### PR TITLE
Dont use top level fields if omitted

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -142,6 +142,10 @@ function Serializer(options) {
                 _.set(payload, 'meta.serializationTime', getElapsedTime());
             }
 
+            if (internal.options.minimizePayload === true || options.minimizePayload === true) {
+                payload = _.omitBy(payload, (property) => _.isObject(property) && _.isEmpty(property));
+            }
+
             return cb(null, payload);
         });
     };

--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -134,7 +134,7 @@ module.exports = function serializeResource(payload, data, options, cb) {
                     return _fn();
                 }
 
-                let include = options.relationships[relationshipName].include || true,
+                let include = _.isUndefined(options.relationships[relationshipName].include) ? true : options.relationships[relationshipName].include,
                     strip = false;
 
                 // if backlisted, exclude

--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -207,6 +207,11 @@ module.exports = function serializeResource(payload, data, options, cb) {
                         }
                     ], _fn);
 
+                    if (options.minimizePayload === true) {
+                        // Remove empty fields
+                        resource.relationships[relationshipName] = _.omitBy(resource.relationships[relationshipName], (property) => _.isObject(property) && _.isEmpty(property));
+                    }
+
                 });
             }, fn);
         }],

--- a/lib/util/serialize-resource.js
+++ b/lib/util/serialize-resource.js
@@ -228,6 +228,18 @@ module.exports = function serializeResource(payload, data, options, cb) {
             fn();
         }]
     }, function(err) {
+
+        if (options.minimizePayload === true) {
+            // Remove empty fields
+            if (!_.isArray(payload.data)) {
+                payload.data = _.omitBy(payload.data, (property) => _.isObject(property) && _.isEmpty(property));
+            } else {
+                payload.data = _.map(payload.data, (doc) => {
+                    return _.omitBy(doc, (property) => _.isObject(property) && _.isEmpty(property));
+                });
+            }
+        }
+
         cb(err);
     });
 };


### PR DESCRIPTION
Top level meta and links fields were being set in the relationships field.
